### PR TITLE
unlimiting eth-brownie version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 dotmap
-eth-brownie>=1.14.0,<1.16.4
+eth-brownie>=1.14.0


### PR DESCRIPTION
is there a reason you constrained it to `<1.16.4`? trying to upgrade to https://github.com/eth-brownie/brownie/releases/tag/v1.17.0